### PR TITLE
Do not send subject code field in metadata.

### DIFF
--- a/classifier/dicom-mr-classifier/dicom-mr-classifier.py
+++ b/classifier/dicom-mr-classifier/dicom-mr-classifier.py
@@ -46,7 +46,6 @@ def dicom_convert(fp, outbase=None):
     metadata['session']['subject'] = {}
     metadata['session']['subject']['sex'] = ds.subj_sex
     metadata['session']['subject']['age'] = ds.subj_age
-    metadata['session']['subject']['code'] = ds.subj_code
     metadata['session']['subject']['firstname'] = ds.subj_firstname
     metadata['session']['subject']['lastname'] = ds.subj_lastname
     metadata['session']['subject']['firstname_hash'] = ds.firstname_hash  # unrecoverable, if anonymizing

--- a/classifier/dicom-mr-classifier/export.sh
+++ b/classifier/dicom-mr-classifier/export.sh
@@ -2,7 +2,7 @@
 # Exports the container in the cwd.
 # The container can be exported once it's started with 
 
-version=0.0.1
+version=0.0.2
 outname=dicom_mr_classifier-$version.tar
 container=dicom-mr-classifier
 image=scitran/dicom-mr-classifier

--- a/classifier/dicom-mr-classifier/info.toml
+++ b/classifier/dicom-mr-classifier/info.toml
@@ -1,5 +1,5 @@
 name    = "dicom_mr_classifier"
-version = "0.0.1"
+version = "0.0.2"
 flywheel = "0"
 url     = "https://github.com/scitran/apps/converters/dicom-mr-classifier"
 license = "apache"


### PR DESCRIPTION
Parsing and sending the patientID field (aka subject code) was causing the field to be (incorrectly) overwritten when it was already correct in the UI.