### PR TITLE
Install python dependencies for qa code via pip.

### DIFF
--- a/qa/qa-report-fmri/Dockerfile
+++ b/qa/qa-report-fmri/Dockerfile
@@ -15,30 +15,32 @@ FROM ubuntu-debootstrap:trusty
 MAINTAINER Michael Perry <lmperry@stanford.edu>
 
 # Install dependencies
-RUN apt-get update && apt-get -y install python-dev \
-   git \
-   libjpeg-dev \
-   zlib1g-dev \
-   pkg-config \
-   libpng12-dev \
-   libfreetype6-dev
+RUN apt-get update && apt-get -y install \
+    python-dev \
+    python-pip \
+    git \
+    libjpeg-dev \
+    zlib1g-dev \
+    pkg-config \
+    libpng12-dev \
+    libfreetype6-dev \
+    libblas-dev \
+    liblapack-dev \
+    libatlas-base-dev \
+    gfortran \
+    zip \
+    unzip
 
 # Link libs: pillow jpegi and zlib support hack
 RUN ln -s /usr/lib/x86_64-linux-gnu/libjpeg.so /usr/lib
 RUN ln -s /usr/lib/x86_64-linux-gnu/libz.so /usr/lib
 
 # Install scitran.data dependencies
-RUN apt-get -y install \
-    python-numpy \
-    python-pip \
-    python-scipy \
-    python-dipy \
-    python-nipy \
-    python-nibabel \
-    zip \
-    unzip
-
-RUN  pip install dipy --upgrade \
+RUN  pip install pip --upgrade \
+    && pip install numpy --upgrade \
+    && pip install scipy --upgrade \
+    && pip install dipy --upgrade \
+    && pip install nibabel --upgrade \
     && pip install nipy --upgrade \
     && pip install matplotlib --upgrade
 

--- a/qa/qa-report-fmri/export.sh
+++ b/qa/qa-report-fmri/export.sh
@@ -2,7 +2,7 @@
 # Exports the container in the cwd.
 # The container can be exported once it's started with 
 
-version=0.1.0
+version=0.1.1
 outname=qa-report-fmri-$version.tar
 container=qa-report-fmri
 image=scitran/qa-report-fmri

--- a/qa/qa-report-fmri/info.toml
+++ b/qa/qa-report-fmri/info.toml
@@ -1,5 +1,5 @@
 name    = "qa-report-fmri"
-version = "0.1.0"
+version = "0.1.1"
 flywheel = "0"
 url     = "https://github.com/scitran/apps/tree/master/qa/qa-report-fmri"
 license = "apache"


### PR DESCRIPTION
Container builds were failing due to apt-get-installed versions of dependencies not playing well with others during the build step. Installing those dependencies via pip (while also installing their dependencies via apt-get) solves this problem. 