### PR TITLE
Use SPDX license strings

### DIFF
--- a/analysis/cmrr-rtmask/manifest.json
+++ b/analysis/cmrr-rtmask/manifest.json
@@ -4,7 +4,7 @@
     "author": "John Strupp, Center for Magnetic Resonance Research",
     "url": "https://www.cmrr.umn.edu/",
     "source": "https://github.com/scitran/apps/analysis/cmrr-rtmask",
-    "license": "apache",
+    "license": "Apache-2.0",
     "flywheel": "0",
     "version": "0.0.2",
     "config": {

--- a/analysis/fsl-bet/manifest.json
+++ b/analysis/fsl-bet/manifest.json
@@ -4,7 +4,7 @@
 	  "author": "Michael Perry <lmperry@stanford.edu>",
     "url": "http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/BET",
     "source": "https://github.com/scitran/apps/analysis/fsl-bet",
-    "license": "apache",
+    "license": "Apache-2.0",
     "flywheel": "0",
     "version": "0.0.5",
     "config": {

--- a/analysis/fsl-fast/manifest.json
+++ b/analysis/fsl-fast/manifest.json
@@ -4,7 +4,7 @@
     "author": "Michael Perry <lmperry@stanford.edu>",
     "url": "http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FAST",
     "source": "https://github.com/scitran/apps/analysis/fsl-fast",
-    "license": "apache",
+    "license": "Apache-2.0",
     "flywheel": "0",
     "version": "0.0.5",
     "config": {

--- a/classifier/dicom-mr-classifier/manifest.json
+++ b/classifier/dicom-mr-classifier/manifest.json
@@ -4,7 +4,7 @@
 	"author": "Michael Perry <lmperry@stanford.edu>",
 	"url": "https://github.com/scitran/data",
 	"source": "https://github.com/scitran/apps/converters/dicom-mr-classifier",
-	"license":  "apache",
+	"license":  "Apache-2.0",
 	"flywheel": "0",
 	"version":  "0.0.9",
 

--- a/converter/dcm-convert/manifest.json
+++ b/converter/dcm-convert/manifest.json
@@ -4,7 +4,7 @@
 	"author": "Michael Perry <lmperry@stanford.edu>",
 	"url": "https://github.com/scitran/data",
 	"source": "https://github.com/scitran/apps/tree/master/converter/dcm-convert",
-	"license":  "apache",
+	"license":  "Apache-2.0",
 	"flywheel": "0",
 	"version":  "0.3.4",
 

--- a/converter/dcm2nii/manifest.json
+++ b/converter/dcm2nii/manifest.json
@@ -4,7 +4,7 @@
 	"author": "Michael Perry <lmperry@stanford.edu>",
 	"url": "https://www.nitrc.org/projects/dcm2nii/",
 	"source": "https://github.com/scitran/apps/tree/master/converter/dcm2nii",
-	"license":  "bsd",
+	"license":  "BSD-2-Clause",
 	"flywheel": "0",
 	"version":  "0.0.6",
 

--- a/qa/qa-report-fmri/manifest.json
+++ b/qa/qa-report-fmri/manifest.json
@@ -4,7 +4,7 @@
 	"author": "Michael Perry <lmperry@stanford.edu>",
 	"url": "https://www.nitrc.org/projects/dcm2nii/",
 	"source": "https://github.com/scitran/apps/tree/master/qa/qa-report-fmri",
-	"license":  "apache",
+	"license":  "Apache-2.0",
 	"flywheel": "0",
 	"version":  "0.1.4",
 


### PR DESCRIPTION
A common community method for programatically identifying a license string is to use the [SPDX identifier](https://spdx.org/licenses). I went ahead & changed our manifest validation to use those strings, and updated the apps to match.