### PR TITLE
Classify: Use pydicom to parse headers and return metadata

### DIFF
--- a/classifier/dicom-mr-classifier/Dockerfile
+++ b/classifier/dicom-mr-classifier/Dockerfile
@@ -10,23 +10,20 @@
 #        /data/outprefix
 #
 
-FROM ubuntu-debootstrap:trusty
+FROM ubuntu:trusty
 
 MAINTAINER Michael Perry <lmperry@stanford.edu>
 
 # Install dependencies
-RUN apt-get update && apt-get -y install python-dev \
-   python-virtualenv \
-   git \
-   libjpeg-dev \
-   zlib1g-dev
+RUN apt-get update && apt-get -y install \
+    python \
+    python-pip
 
 
 # Install scitran.data dependencies
 RUN pip install \
     pytz \
-    pydicom \
-    tzlocal
+    pydicom
 
 # Make directory for flywheel spec (v0)
 ENV FLYWHEEL /flywheel/v0
@@ -34,8 +31,10 @@ RUN mkdir -p ${FLYWHEEL}
 COPY run ${FLYWHEEL}/run
 COPY manifest.json ${FLYWHEEL}/manifest.json
 
-# Put the python code in place
+# Add code to determine measurement from dicom descrip (label)
 ADD https://raw.githubusercontent.com/scitran/utilities/master/measurement_from_label.py ${FLYWHEEL}/measurement_from_label.py
+
+# Copy classifier code into place
 COPY dicom-mr-classifier.py ${FLYWHEEL}/dicom-mr-classifier.py
 
 # Set the entrypoint

--- a/classifier/dicom-mr-classifier/Dockerfile
+++ b/classifier/dicom-mr-classifier/Dockerfile
@@ -1,7 +1,6 @@
 # scitran/dicom-mr-classifier
 #
-# Use Scitran Data to classify raw DICOM data (zip) from Siemens or GE.
-# See http://github.com/scitran/data for source code.
+# Use pyDicom to classify raw DICOM data (zip) from Siemens, GE or Philips.
 #
 # Example usage:
 #   docker run --rm -ti \
@@ -22,20 +21,12 @@ RUN apt-get update && apt-get -y install python-dev \
    libjpeg-dev \
    zlib1g-dev
 
-# Link libs: pillow jpegi and zlib support hack
-RUN ln -s /usr/lib/x86_64-linux-gnu/libjpeg.so /usr/lib
-RUN ln -s /usr/lib/x86_64-linux-gnu/libz.so /usr/lib
 
 # Install scitran.data dependencies
 RUN pip install \
-    numpy==1.9.0 \
     pytz \
-    tzlocal \
-    pillow \
-    git+https://github.com/scitran/pydicom.git@0.9.9_value_vr_mismatch \
-    git+https://github.com/nipy/nibabel.git@3bc31e9a6191fc54667b3387ed5dfaced46bf755 \
-    git+https://github.com/moloney/dcmstack.git@6d49fe01235c08ae63c76fa2f3943b49c9b9832d \
-    git+https://github.com/scitran/data.git@a516fdc39d75a6e4ac75d0e179e18f3a5fc3c0af
+    pydicom \
+    tzlocal
 
 # Make directory for flywheel spec (v0)
 ENV FLYWHEEL /flywheel/v0
@@ -44,6 +35,7 @@ COPY run ${FLYWHEEL}/run
 COPY manifest.json ${FLYWHEEL}/manifest.json
 
 # Put the python code in place
+ADD https://raw.githubusercontent.com/scitran/utilities/master/measurement_from_label.py ${FLYWHEEL}/measurement_from_label.py
 COPY dicom-mr-classifier.py ${FLYWHEEL}/dicom-mr-classifier.py
 
 # Set the entrypoint

--- a/classifier/dicom-mr-classifier/build.sh
+++ b/classifier/dicom-mr-classifier/build.sh
@@ -4,4 +4,4 @@
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-docker build --no-cache --tag scitran/dicom-mr-classifier:classify $DIR
+docker build --no-cache --tag scitran/dicom-mr-classifier $DIR

--- a/classifier/dicom-mr-classifier/build.sh
+++ b/classifier/dicom-mr-classifier/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Builds the dcm-convert container. 
+# Builds the dcm-convert container.
 # The container can be exported using the export.sh script
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-docker build --no-cache --tag scitran/dicom-mr-classifier $DIR
+docker build --no-cache --tag scitran/dicom-mr-classifier:classify $DIR

--- a/classifier/dicom-mr-classifier/export.sh
+++ b/classifier/dicom-mr-classifier/export.sh
@@ -2,7 +2,7 @@
 # Exports the container in the cwd.
 # The container can be exported once it's started with
 
-version=0.0.9
+version=0.1.0
 outname=dicom_mr_classifier-$version.tar
 container=dicom-mr-classifier
 image=scitran/dicom-mr-classifier

--- a/classifier/dicom-mr-classifier/manifest.json
+++ b/classifier/dicom-mr-classifier/manifest.json
@@ -1,12 +1,12 @@
 {
 	"name":     "dicom_mr_classifier",
-	"description": "Use Scitran/Data to classify raw DICOM data from Siemens or GE.",
+	"description": "Extract metadata from raw DICOM data from Siemens, Philips, or GE.",
 	"author": "Michael Perry <lmperry@stanford.edu>",
-	"url": "https://github.com/scitran/data",
+	"url": "https://scitran.github.io",
 	"source": "https://github.com/scitran/apps/converters/dicom-mr-classifier",
 	"license":  "Apache-2.0",
 	"flywheel": "0",
-	"version":  "0.0.9",
+	"version":  "0.1.0",
 
 	"config": {
 	},

--- a/classifier/dicom-mr-classifier/run
+++ b/classifier/dicom-mr-classifier/run
@@ -31,13 +31,13 @@ if [[ -z $@ ]]
         then
             bni=`basename "$input_file"`
             output_file_base=$OUTPUT_DIR/${bni%_dicom.zip}
-            /flywheel/v0/dicom-mr-classifier.py "$input_file" "$output_file_base"
+            PYHONPATH=$PYTHONPATH:/flywheel/v0/ python $FLYWHEEL_BASE/dicom-mr-classifier.py "$input_file" "$output_file_base"
       else
             echo -e "No inputs were provided and $INPUT_DIR has no valid input files!"
             exit 1
       fi
 else
-    $FLYWHEEL_BASE/dicom-mr-classifier.py $@
+    PYHONPATH=$PYTHONPATH:/flywheel/v0/ python $FLYWHEEL_BASE/dicom-mr-classifier.py $@
 fi
 
 


### PR DESCRIPTION
The major change here is the removal of the scitran/data dependency and the use of pydicom to parse dicom headers and return metadata. 

This code also pulls in measurement_from_label.py code from scitran/utilities to determine measurement type. 

